### PR TITLE
Fix bugs in import/export scripts

### DIFF
--- a/scripts/wezterm_ssh_export.sh
+++ b/scripts/wezterm_ssh_export.sh
@@ -292,5 +292,5 @@ echo
 print_success "Export process complete! 🚀"
 echo
 echo "To import this configuration:"
-echo "  ~/.config/wezterm/ssh_import.sh"
+echo "  wezterm_ssh_import.sh"
 echo

--- a/scripts/wezterm_ssh_import.sh
+++ b/scripts/wezterm_ssh_import.sh
@@ -326,7 +326,7 @@ EOF
     
 else
     # Merge mode with migration
-    python3 << EOF
+    ADDED_COUNT=$(python3 << EOF
 import json
 import os
 
@@ -402,25 +402,6 @@ elif '$IMPORT_HAS_FOLDERS' == 'False' and '$CURRENT_HAS_FOLDERS' == 'true' and n
         json.dump(default_folders, f, indent=2)
 
 print(f"{added_count}")
-EOF
-    
-    # Extract the added count from the Python script output
-    ADDED_COUNT=$(python3 << 'EOF'
-import json
-
-# Load import data
-with open('$TEMP_DECRYPTED', 'r') as f:
-    import_data = json.load(f)
-
-# Load existing servers 
-existing_servers = []
-if int('$CURRENT_SERVER_COUNT') > 0:
-    with open('$SERVERS_FILE', 'r') as f:
-        existing_servers = json.load(f)
-
-existing_names = {server['name'] for server in existing_servers}
-added_count = sum(1 for server in import_data['servers'] if server['name'] not in existing_names)
-print(added_count)
 EOF
 )
     


### PR DESCRIPTION
Fixed bugs found during verification:

1. Export script referenced wrong import script path
   - Was: ~/.config/wezterm/ssh_import.sh
   - Fixed: wezterm_ssh_import.sh (correct PATH location)

2. Import script had redundant added_count calculation in merge mode
   - Removed duplicate Python block that recalculated the same value
   - Fixed variable capture for ADDED_COUNT in merge mode

These fixes improve script reliability and user experience.

🤖 Generated with [Claude Code](https://claude.ai/code)